### PR TITLE
Add landing page components

### DIFF
--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -1,0 +1,14 @@
+import { HeroSection, Services, Projects, About, ContactForm, Footer } from "@/components/landing"
+
+export default function LandingPage() {
+  return (
+    <>
+      <HeroSection />
+      <Services />
+      <Projects />
+      <About />
+      <ContactForm />
+      <Footer />
+    </>
+  )
+}

--- a/components/landing/about.tsx
+++ b/components/landing/about.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+export default function About() {
+  return (
+    <section className="py-20 bg-white text-center">
+      <h2 className="text-4xl font-bold mb-6 text-devloopAccent">Quem Somos</h2>
+      <p className="max-w-3xl mx-auto text-lg text-gray-700">
+        A DevLoop é uma empresa que nasceu com a missão de transformar negócios
+        através da tecnologia, automação e design. Somos engenheiros, designers e
+        criativos, prontos para construir soluções digitais que geram resultados reais.
+      </p>
+    </section>
+  )
+}

--- a/components/landing/contact-form.tsx
+++ b/components/landing/contact-form.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+export default function ContactForm() {
+  return (
+    <section className="py-20 bg-slate-100 text-center">
+      <h2 className="text-4xl font-bold mb-6 text-devloopAccent">Solicite uma Proposta</h2>
+      <form className="max-w-xl mx-auto space-y-6">
+        <input
+          type="text"
+          placeholder="Seu nome"
+          className="w-full px-4 py-3 border rounded-xl"
+        />
+        <input
+          type="email"
+          placeholder="Seu e-mail"
+          className="w-full px-4 py-3 border rounded-xl"
+        />
+        <textarea
+          placeholder="Descreva seu projeto ou ideia"
+          className="w-full px-4 py-3 border rounded-xl"
+          rows={5}
+        />
+        <button
+          type="submit"
+          className="w-full px-6 py-3 bg-devloopAccent text-white rounded-xl"
+        >
+          Enviar Mensagem
+        </button>
+      </form>
+    </section>
+  )
+}

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+export default function Footer() {
+  return (
+    <footer className="bg-devloopAccent text-white py-6 text-center">
+      <p>© DevLoop 2025 – Do conceito ao código. Do código ao resultado.</p>
+      <div className="mt-2 space-x-4">
+        <a href="https://instagram.com" target="_blank">Instagram</a>
+        <a href="https://github.com" target="_blank">GitHub</a>
+        <a href="mailto:sthevan.ssantos@gmail.com">E-mail</a>
+      </div>
+    </footer>
+  )
+}

--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+export default function HeroSection() {
+  return (
+    <section className="bg-gradient-to-b from-devloopAccent to-devloopPrimary text-white py-24 text-center">
+      <h1 className="text-5xl md:text-6xl font-bold mb-6">
+        DevLoop – Do conceito ao código
+      </h1>
+      <p className="text-xl md:text-2xl max-w-2xl mx-auto">
+        Criamos sistemas, automações e designs que transformam negócios.
+        Da ideia ao resultado.
+      </p>
+      <div className="mt-8 flex justify-center gap-4">
+        <a
+          href="#projetos"
+          className="px-6 py-3 bg-white text-devloopAccent rounded-xl font-semibold"
+        >
+          Ver Portfólio
+        </a>
+        <a
+          href="#contato"
+          className="px-6 py-3 border border-white rounded-xl"
+        >
+          Solicitar Proposta
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/components/landing/index.ts
+++ b/components/landing/index.ts
@@ -1,0 +1,6 @@
+export { default as HeroSection } from "./hero-section"
+export { default as Services } from "./services"
+export { default as Projects } from "./projects"
+export { default as About } from "./about"
+export { default as ContactForm } from "./contact-form"
+export { default as Footer } from "./footer"

--- a/components/landing/projects.tsx
+++ b/components/landing/projects.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+const projects = [
+  {
+    name: "Zap Click",
+    description: "Sistema de funil e automação para WhatsApp com integração inteligente.",
+  },
+  {
+    name: "Secretária.IA",
+    description: "Bot de voz, transcrição e automação de atendimento com IA.",
+  },
+  {
+    name: "DevLoop Cloud",
+    description: "Sistema interno de nuvem e gestão digital desenvolvido pela DevLoop.",
+  },
+]
+
+export default function Projects() {
+  return (
+    <section className="py-20 bg-slate-100 text-center">
+      <h2 className="text-4xl font-bold mb-10 text-devloopAccent">Projetos em Destaque</h2>
+      <div className="grid gap-8 md:grid-cols-3 max-w-6xl mx-auto">
+        {projects.map((project) => (
+          <div key={project.name} className="p-8 border rounded-xl shadow-md hover:shadow-xl transition">
+            <h3 className="text-2xl font-semibold mb-4">{project.name}</h3>
+            <p className="text-gray-700">{project.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/landing/services.tsx
+++ b/components/landing/services.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+const services = [
+  {
+    title: "Criação de Sites e Sistemas",
+    description: "Soluções sob medida com segurança, performance e design incrível.",
+  },
+  {
+    title: "Automação e Bots",
+    description: "Automatizamos processos, atendimento e integrações com IA.",
+  },
+  {
+    title: "Design e Identidade Visual",
+    description: "Construção de marcas, posts, reels e identidades visuais completas.",
+  },
+  {
+    title: "Manutenção e Segurança",
+    description: "Monitoramento, correções e suporte contínuo para empresas.",
+  },
+]
+
+export default function Services() {
+  return (
+    <section className="py-20 bg-white text-center">
+      <h2 className="text-4xl font-bold mb-10 text-devloopAccent">Nossos Serviços</h2>
+      <div className="grid gap-8 md:grid-cols-2 max-w-6xl mx-auto">
+        {services.map((service) => (
+          <div key={service.title} className="p-8 border rounded-xl shadow-md hover:shadow-xl transition">
+            <h3 className="text-2xl font-semibold mb-4">{service.title}</h3>
+            <p className="text-gray-700">{service.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add simple landing components with hero, services, projects, about, contact and footer sections
- provide a landing page that assembles the new components

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cd1c4ca508328b12d7321a66b19ed